### PR TITLE
Fix: dossier plugin , Multilingue: Ajout link rel alternate

### DIFF
--- a/plxMySearch.php
+++ b/plxMySearch.php
@@ -18,8 +18,14 @@ class plxMySearch extends plxPlugin {
 	public function __construct($default_lang) {
 
 		# gestion du multilingue plxMyMultiLingue
-		if(preg_match('/([a-z]{2})\/(.*)/i', plxUtils::getGets(), $capture)) {
-				$this->lang = $capture[1].'/';
+		$this->lang='';
+		if(defined('PLX_MYMULTILINGUE')) {
+			$lang = plxMyMultiLingue::_Lang();
+			if(!empty($lang)) {
+				if(isset($_SESSION['default_lang']) AND $_SESSION['default_lang']!=$lang) {
+					$this->lang = $lang.'/';
+				}
+			}
 		}
 
 		# appel du constructeur de la classe plxPlugin (obligatoire)
@@ -46,8 +52,34 @@ class plxMySearch extends plxPlugin {
 			$this->addHook('plxShowPageTitle', 'plxShowPageTitle');
 			$this->addHook('SitemapStatics', 'SitemapStatics');
 			$this->addHook('MySearchForm', 'form');
+			if(defined('PLX_MYMULTILINGUE')) {
+				$this->addHook('ThemeEndHead', 'ThemeEndHead');
+			}
 		}
 
+	}
+
+	/** 
+	 * Méthode d'ajout des <link rel="alternate"... sur les pages
+	 * 
+	**/
+	public function ThemeEndHead() {
+		
+		if(defined('PLX_MYMULTILINGUE')) {			
+			$plxMML = is_array(PLX_MYMULTILINGUE)?PLX_MYMULTILINGUE:unserialize(PLX_MYMULTILINGUE);
+			$langues = empty($plxMML['langs']) ? array() : explode(',', $plxMML['langs']);;
+			$string = '<?php
+			if($plxMotor->mode=="'.$this->getParam('url').'") {
+			';
+			foreach($langues as $k=>$v)
+			{
+				$url_lang="";
+				if($_SESSION['default_lang']!=$v) $url_lang = $v.'/';
+				$string .= 'echo "\t<link rel=\"alternate\" hreflang=\"'.$v.'\" href=\"".$plxMotor->urlRewrite("?'.$url_lang.$this->getParam('url').'")."\" />\n";';
+			}
+			$string .= '} ?>';
+			echo $string;
+		}
 	}
 
 	/**
@@ -117,7 +149,7 @@ class plxMySearch extends plxPlugin {
 		if(\$this->get && preg_match('/^".$this->url."\/?/',\$this->get)) {
 			\$this->mode = '".$this->url."';
 			\$prefix = str_repeat('../', substr_count(trim(PLX_ROOT.\$this->aConf['racine_statiques'], '/'), '/'));
-			\$this->cible = \$prefix.'plugins/plxMySearch/form';
+			\$this->cible = \$prefix.\$this->aConf['racine_plugins'].'plxMySearch/form';
 			\$this->template = '".$template."';
 			return true;
 		}


### PR DESCRIPTION
Fix pour : nom du dossier plugin en dur causant des problèmes.
Gestion des langues mis à jour.
Ajout des link rel alternate sur la page de recherche