### PR TITLE
Fix issue #11

### DIFF
--- a/form.search.php
+++ b/form.search.php
@@ -1,10 +1,6 @@
 <?php if(!defined('PLX_ROOT')) exit; ?>
 <?php
 
-function getParam($p) {
-	return ($p=='' OR $p=='1');
-}
-
 # récupération d'une instance de plxMotor
 $plxMotor = plxMotor::getInstance();
 $plxPlugin = $plxMotor->plxPlugins->getInstance('plxMySearch');


### PR DESCRIPTION
Proposition to fix https://github.com/Pluxopolis/plxMySearch/issues/11

The method getParam declared here seems to be unnecessary. Actually it is the cause of a php fatal error "Cannot redeclare getParam()" that prevent to display the footer of the search page.